### PR TITLE
installer: auto-detect cloud from workspace_url

### DIFF
--- a/dbdemos/installer.py
+++ b/dbdemos/installer.py
@@ -27,13 +27,18 @@ from dbdemos.sql_query import SQLQueryExecutor
 from databricks.sdk import WorkspaceClient
 
 class Installer:
-    def __init__(self, username = None, pat_token = None, workspace_url = None, cloud = "AWS", org_id: str = None, current_cluster_id: str = None):
-        self.cloud = cloud
+    def __init__(self, username = None, pat_token = None, workspace_url = None, cloud = None, org_id: str = None, current_cluster_id: str = None):
         self.dbutils = None
         if username is None:
             username = self.get_current_username()
         if workspace_url is None:
             workspace_url = self.get_current_url()
+        # Auto-detect cloud from workspace_url when caller didn't pass one explicitly.
+        # The previous default was "AWS", which silently produced wrong node_type_id
+        # values on Azure and GCP workspaces.
+        if cloud is None:
+            cloud = self._infer_cloud_from_url(workspace_url) or "AWS"
+        self.cloud = cloud
         if pat_token is None:
             pat_token = self.get_current_pat_token()
         if org_id is None:
@@ -80,6 +85,26 @@ class Installer:
                 return "https://"+self.get_dbutils_tags_safe()['browserHostName']
             except:
                 return "local"
+
+    @staticmethod
+    def _infer_cloud_from_url(workspace_url):
+        """Infer Databricks cloud from workspace URL hostname.
+
+        Returns one of ``"AZURE"``, ``"GCP"``, ``"AWS"`` or ``None`` if the URL
+        is missing / local / unrecognizable. Used so the ``Installer.__init__``
+        ``cloud`` argument doesn't need to be passed explicitly on Azure / GCP
+        workspaces.
+        """
+        if not workspace_url or workspace_url == "local":
+            return None
+        url = workspace_url.lower()
+        if "azuredatabricks.net" in url:
+            return "AZURE"
+        if "gcp.databricks.com" in url:
+            return "GCP"
+        if "cloud.databricks.com" in url or "databricks.com" in url:
+            return "AWS"
+        return None
 
     def get_dbutils_tags_safe(self):
         import json

--- a/test/test_installer.py
+++ b/test/test_installer.py
@@ -69,3 +69,17 @@ def test_list_html():
 #test_list_html()
 #test_list()
 #test_html()
+
+
+def test_infer_cloud_from_url():
+    f = Installer._infer_cloud_from_url
+    assert f("https://adb-1234567890.0.azuredatabricks.net") == "AZURE"
+    assert f("https://adb-XXXX.0.azuredatabricks.net/?o=1234") == "AZURE"
+    assert f("https://e2-demo-tools.cloud.databricks.com") == "AWS"
+    assert f("https://workspace.cloud.databricks.com") == "AWS"
+    assert f("https://workspace.gcp.databricks.com") == "GCP"
+    assert f(None) is None
+    assert f("local") is None
+    assert f("") is None
+    # Mixed-case host
+    assert f("https://ADB-1234.0.AzureDatabricks.net") == "AZURE"


### PR DESCRIPTION
## Summary

Auto-detect cloud from `workspace_url` when caller doesn't pass `cloud=`
explicitly to `Installer(...)`.

`Installer.__init__` previously defaulted `cloud="AWS"`. On Azure and GCP
workspaces this silently produced wrong `node_type_id` values
(`g5.4xlarge` instead of `Standard_NC8as_T4_v3` or `a2-highgpu-1g`),
making cluster creation fail with a cryptic node-type error. Users had to
know to pass `cloud="AZURE"` or `cloud="GCP"` explicitly.

Change `cloud=` default to `None` and infer from `workspace_url`:
- `*.azuredatabricks.net` → `AZURE`
- `*.gcp.databricks.com` → `GCP`
- `*.cloud.databricks.com` (or any other `databricks.com`) → `AWS`

When inference fails (workspace_url is `None` or `"local"`, e.g. running
outside a notebook context with no override), fall back to `AWS` to preserve
the old default. Caller can still pass `cloud=` explicitly to override.

## Why

This is one of three blockers that fail-fast new-user installs on Azure/GCP
workspaces (the other two are catalog-default `main` and the dotted-tag bug,
which I'll send as follow-up issues). On 35-demo serverless rollout testing
across our Azure workspace, the missing `cloud="AZURE"` kwarg accounted for
several install failures before the workaround was documented.

## Test plan

- [x] Added unit test `test_infer_cloud_from_url` covering AZURE / GCP / AWS
      hosts, mixed case, missing URL, and `"local"`.
- [x] Existing `test_installer.py` tests pass locally (function-level test
      isolation via the static method).

This pull request and its description were written by Isaac.
