### PR TITLE
sql_query: spark.sql fallback for dotted custom-tag failures

### DIFF
--- a/dbdemos/sql_query.py
+++ b/dbdemos/sql_query.py
@@ -10,6 +10,10 @@ from dbdemos.exceptions.dbdemos_exception import SQLQueryException
 class SQLQueryExecutor:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
+        # Once we hit the dotted-tag bug on the Statement Execution API, every
+        # subsequent call will hit it too — flip this flag so we go straight to
+        # the spark.sql fallback instead of paying the timeout each time.
+        self._prefer_spark_sql = False
 
     def get_or_create_shared_warehouse(self, ws: WorkspaceClient) -> str:
         warehouses = ws.warehouses.list()
@@ -41,17 +45,42 @@ class SQLQueryExecutor:
         return self.get_results_formatted_as_list(data, manifest)
 
     def execute_query(self, ws: WorkspaceClient, query: str, timeout: int = 50, warehouse_id: str = None, debug: bool = False) -> tuple[ResultData, ResultManifest]:
+        # If we've already established that this workspace's Statement Execution
+        # API rejects dotted custom-tag keys, skip the SDK call and use spark.sql
+        # directly (when available). This avoids paying the timeout per call.
+        if self._prefer_spark_sql:
+            spark_result = self._try_spark_sql_fallback(query)
+            if spark_result is not None:
+                return spark_result
         if not warehouse_id:
             warehouse_id = self.get_or_create_shared_warehouse(ws)
         if debug:
             print(f"Executing query: {query} with warehouse {warehouse_id}")
         # Execute the query with a maximum wait timeout of 50 seconds
-        statement = ws.statement_execution.execute_statement(
-            warehouse_id=warehouse_id,
-            statement=query,
-            wait_timeout=f"{timeout}s",
-            on_wait_timeout=ExecuteStatementRequestOnWaitTimeout.CONTINUE
-        )
+        try:
+            statement = ws.statement_execution.execute_statement(
+                warehouse_id=warehouse_id,
+                statement=query,
+                wait_timeout=f"{timeout}s",
+                on_wait_timeout=ExecuteStatementRequestOnWaitTimeout.CONTINUE
+            )
+        except Exception as e:
+            # The Statement Execution API rejects workspace custom_tags whose
+            # keys contain `.` (e.g. `system.Certified`, auto-added on some
+            # internal / managed workspaces). On affected workspaces every
+            # SDK-driven query call will fail the same way. Fall back to
+            # spark.sql when we have an active SparkSession.
+            if self._looks_like_dotted_tag_failure(e):
+                spark_result = self._try_spark_sql_fallback(query)
+                if spark_result is not None:
+                    self.logger.warning(
+                        "Statement Execution API failed with a tag-related "
+                        "error; using spark.sql for subsequent calls. "
+                        "Original error: %s", e,
+                    )
+                    self._prefer_spark_sql = True
+                    return spark_result
+            raise
         
         # If the statement is not completed within the wait_timeout, poll for results
         while statement.status.state in [StatementState.PENDING, StatementState.RUNNING]:
@@ -84,12 +113,49 @@ class SQLQueryExecutor:
 
     def get_results_formatted_as_list(self, result_data: ResultData, result_manifest: ResultManifest) -> List[Dict[str, Any]]:
         column_names = [col.name for col in result_manifest.schema.columns]
-        
+
         result_list = []
-        
-        if result_data.data_array:  
+
+        if result_data.data_array:
             for row in result_data.data_array:
                 result_dict = {column_names[i]: value for i, value in enumerate(row)}
                 result_list.append(result_dict)
-        
+
         return result_list
+
+    @staticmethod
+    def _looks_like_dotted_tag_failure(exc) -> bool:
+        """Heuristic: does this exception look like the dotted custom-tag bug?
+
+        The Statement Execution API rejects workspace ``custom_tags`` whose keys
+        contain ``.`` (e.g. ``system.Certified`` on certain managed workspaces).
+        The SDK surfaces this as a generic SDK error mentioning ``tag`` and
+        either ``invalid`` / ``name`` / ``dotted``. Be permissive — false
+        positives only mean we fall through to spark.sql, which usually works.
+        """
+        msg = str(exc).lower()
+        if "tag" not in msg:
+            return False
+        return any(token in msg for token in ("invalid", "name", "dotted", "."))
+
+    def _try_spark_sql_fallback(self, query: str):
+        """Run the query via ``spark.sql`` when a SparkSession is available.
+
+        Returns a ``(ResultData, None)`` tuple matching the SDK signature, or
+        ``None`` when no SparkSession is available (in which case the caller
+        must fall back to re-raising the original error).
+        """
+        try:
+            from pyspark.sql import SparkSession
+        except ImportError:
+            return None
+        spark = SparkSession.getActiveSession()
+        if spark is None:
+            return None
+        try:
+            df = spark.sql(query)
+            data_array = [[str(c) if c is not None else None for c in row] for row in df.collect()]
+            return ResultData(data_array=data_array), None
+        except Exception as e:
+            self.logger.warning("spark.sql fallback also failed: %s", e)
+            return None


### PR DESCRIPTION
## Summary

The Statement Execution API rejects workspace `custom_tags` whose keys contain `.` (e.g. `system.Certified`, auto-added on certain managed workspaces). When the workspace has any such tag, every `dbdemos.sql_query.SQLQueryExecutor.execute_query` call fails identically, and installs that touch the SQL warehouse path (`aibi-marketing-campaign` is the worst hit; we see it fail 100% of the time on the affected internal workspace) abort.

When `execute_statement` raises something that looks like the tag-name failure, fall back to `spark.sql` if an active SparkSession is available. Cache the decision (`self._prefer_spark_sql`) so subsequent calls skip the SDK round-trip entirely. Re-raise the original error if no SparkSession is available (preserving the prior behavior for headless / CI runs without spark).

## Why

Without this, the `aibi-marketing-campaign` demo and any other demo that hits the SQL warehouse path is permanently broken on affected workspaces. The current workaround that the field has been using is a monkey-patch over `SQLQueryExecutor.execute_query` in a notebook cell before calling `dbdemos.install()`. Folding the same logic into the installer removes the need for that workaround.

## Detection heuristic

Permissive — matches any exception whose message contains both `tag` and one of `invalid` / `name` / `dotted` / `.`. False positives just trigger the spark.sql fallback (which itself is gated on having an active SparkSession), so the worst case is a slightly noisier error path when `spark.sql` also rejects the query.

## Companion

Original cloud-detection PR: https://github.com/databricks-demos/dbdemos/pull/260 . Both ride together on the "make dbdemos.install() work on Azure serverless without monkey-patches" branch of work.

This pull request and its description were written by Isaac.
