### PR TITLE
Migrate Genie to SDK, publish dashboards, add env-driven package.py

### DIFF
--- a/dbdemos/installer.py
+++ b/dbdemos/installer.py
@@ -27,8 +27,9 @@ from dbdemos.sql_query import SQLQueryExecutor
 from databricks.sdk import WorkspaceClient
 
 class Installer:
-    def __init__(self, username = None, pat_token = None, workspace_url = None, cloud = "AWS", org_id: str = None, current_cluster_id: str = None):
-        self.cloud = cloud
+    def __init__(self, username = None, pat_token = None, workspace_url = None, cloud = None, org_id: str = None, current_cluster_id: str = None):
+        # Explicit override; when None the cloud is inferred from the workspace URL (see get_current_cloud).
+        self.cloud_override = cloud
         self.dbutils = None
         if username is None:
             username = self.get_current_username()
@@ -153,17 +154,27 @@ class Installer:
                     return "unknown"
 
     def get_current_cloud(self):
-        try:
-            hostname = self.get_dbutils().notebook.entry_point.getDbutils().notebook().getContext().browserHostName().get()
-        except:
-            print(f"WARNING: Can't get cloud from dbutils. Fallback to default local cloud {self.cloud}")
-            return self.cloud
-        if "gcp" in hostname:
-            return "GCP"
-        elif "azure" in hostname:
+        if self.cloud_override:
+            return self.cloud_override
+        return self._infer_cloud_from_url(self.db.conf.workspace_url) or "AWS"
+
+    @staticmethod
+    def _infer_cloud_from_url(workspace_url):
+        """Infer the Databricks cloud from the workspace URL hostname.
+
+        Returns one of "AZURE", "GCP", "AWS", or None if the URL is missing /
+        local / unrecognizable (callers fall back to "AWS").
+        """
+        if not workspace_url or workspace_url == "local":
+            return None
+        url = workspace_url.lower()
+        if "azuredatabricks.net" in url:
             return "AZURE"
-        else:
+        if "gcp.databricks.com" in url:
+            return "GCP"
+        if "databricks.com" in url:
             return "AWS"
+        return None
         
     def get_current_cluster_id(self):
         try:

--- a/dbdemos/installer_dashboard.py
+++ b/dbdemos/installer_dashboard.py
@@ -77,4 +77,23 @@ class InstallerDashboard:
         })
         dashboard['uid'] = dashboard_creation['dashboard_id']
         dashboard['is_lakeview'] = True
+        self.publish_dashboard(dashboard, endpoint['warehouse_id'])
         return dashboard
+
+    def publish_dashboard(self, dashboard, warehouse_id):
+        """Publish the dashboard so it's directly accessible, and store the published URL.
+
+        Publishing failures are non-fatal: the draft dashboard is still installed, we just
+        won't have a published link to show.
+        """
+        from databricks.sdk import WorkspaceClient
+        try:
+            ws = WorkspaceClient(token=self.db.conf.pat_token, host=self.db.conf.workspace_url)
+            ws.lakeview.publish(dashboard['uid'], embed_credentials=False, warehouse_id=warehouse_id)
+            published_url = f"{self.db.conf.workspace_url}/dashboardsv3/{dashboard['uid']}/published"
+            if self.db.conf.org_id and self.db.conf.org_id != "local":
+                published_url += f"?o={self.db.conf.org_id}"
+            dashboard['published_url'] = published_url
+        except Exception as e:
+            print(f"WARN: couldn't publish dashboard '{dashboard.get('name')}' ({dashboard['uid']}): {e}. "
+                  f"The draft dashboard is still available.")

--- a/dbdemos/installer_genie.py
+++ b/dbdemos/installer_genie.py
@@ -48,57 +48,90 @@ class InstallerGenie:
         ws = WorkspaceClient(token=self.installer.db.conf.pat_token, host=self.installer.db.conf.workspace_url)
         self.create_temp_table_for_genie_creation(ws, room, warehouse_id, debug)
         room.display_name = room.display_name.replace("/", "-")
-        room_payload = {
-            "display_name": room.display_name,
-            "description": room.description,
-            "warehouse_id": warehouse_id,
-            "table_identifiers": room.table_identifiers,
-            "parent_folder": f'folders/{genie_path["object_id"]}',
-            "run_as_type": "VIEWER"
-        }
-        created_room = self.db.post("2.0/data-rooms", json=room_payload)
-        if 'id' not in created_room:
-            raise GenieCreationException(f"Error creating room {room_payload} - {created_room}", room, created_room)
-
+        serialized_space = self.build_serialized_space(room)
         if debug:
-            print(f"Genie room created created_room: {created_room} - {room_payload}")
-        actions = [{
-            "action_type": "CREATE",
-            "curated_question": {
-                "data_room_id": created_room['id'],
-                "question_text": q,
-                "question_type": "SAMPLE_QUESTION"
-            }
-        } for q in room.curated_questions]
-        questions = self.db.post(f"2.0/data-rooms/{created_room['id']}/curated-questions/batch-actions", {"actions": actions})
+            print(f"Creating genie space '{room.display_name}' under {genie_path['path']} with payload: {serialized_space}")
+        try:
+            created_space = ws.genie.create_space(
+                warehouse_id=warehouse_id,
+                serialized_space=serialized_space,
+                title=room.display_name,
+                description=room.description,
+                parent_path=genie_path["path"],
+            )
+        except Exception as e:
+            raise GenieCreationException(f"Error creating genie space '{room.display_name}': {e}", room, str(e))
         if debug:
-            print(f"Genie room question created:{questions}")
-        if room.instructions:
-            instructions = self.db.post(f"2.0/data-rooms/{created_room['id']}/instructions", {"title": "Notes", "content": room.instructions, "instruction_type": "TEXT_INSTRUCTION"})
-            if debug:
-                print(f"genie room instructions: {instructions}")
-        
-        for function_name in room.function_names:
-            instructions = self.db.post(f"2.0/data-rooms/{created_room['id']}/instructions", {"title": "SQL Function", "content": function_name, "instruction_type": "CERTIFIED_ANSWER"})
-            if debug:
-                print(f"genie room function: {instructions}")
-        for sql in room.sql_instructions:
-            instructions = self.db.post(f"2.0/data-rooms/{created_room['id']}/instructions", {"title": sql['title'], "content": sql['content'], "instruction_type": "SQL_INSTRUCTION"})
-            if debug:
-                print(f"genie room SQL instructions: {instructions}")
-        for b in room.benchmarks:
-            benchmark =    {
-                            "question_text": b["question_text"],
-                            "question_type":"BENCHMARK",
-                            "answer_text": b["answer_text"],
-                            "is_deprecated": False,
-                            "updatable_fields_mask":[]
-                            }
-            instructions = self.db.post(f"2.0/data-rooms/{created_room['id']}/curated-questions", {"curated_question": benchmark, "data_room_id":created_room['id']})
-            if debug:
-                print(f"genie room benchmarks: {instructions}")
+            print(f"Genie space created: {created_space.space_id} - {room.display_name}")
         self.delete_temp_table_for_genie_creation(ws, room, debug)
-        return {"id": room.id, "uid": created_room['id'], 'name': room.display_name}
+        return {"id": room.id, "uid": created_space.space_id, 'name': room.display_name}
+
+    @staticmethod
+    def build_serialized_space(room: GenieRoom) -> str:
+        """Build the ``serialized_space`` JSON payload consumed by ``GenieAPI.create_space``.
+
+        The Genie space API takes the full space definition as a single serialized
+        JSON string (schema version 2). Each text field is encoded as a list of
+        string chunks that the platform concatenates. We assign deterministic ids
+        (prefixed per section) so the payload is stable across re-installs.
+        """
+        space = {
+            "version": 2,
+            "config": {
+                "sample_questions": [
+                    {"id": InstallerGenie._genie_id("1", i), "question": [q]}
+                    for i, q in enumerate(room.curated_questions or [])
+                ]
+            },
+            "data_sources": {
+                # The Genie API requires tables to be sorted by identifier.
+                "tables": [{"identifier": t} for t in sorted(room.table_identifiers or [])]
+            },
+            "instructions": {},
+        }
+
+        instructions = space["instructions"]
+        if room.instructions:
+            instructions["text_instructions"] = [
+                {"id": InstallerGenie._genie_id("3", 0), "content": [room.instructions]}
+            ]
+        if room.sql_instructions:
+            instructions["example_question_sqls"] = [
+                {
+                    "id": InstallerGenie._genie_id("2", i),
+                    "question": [sql["title"]],
+                    "sql": [sql["content"]],
+                }
+                for i, sql in enumerate(room.sql_instructions)
+            ]
+        if room.function_names:
+            instructions["sql_functions"] = [
+                {"id": InstallerGenie._genie_id("4", i), "identifier": fn}
+                for i, fn in enumerate(room.function_names)
+            ]
+        if room.benchmarks:
+            space["benchmarks"] = {
+                "questions": [
+                    {
+                        "id": InstallerGenie._genie_id("5", i),
+                        "question": [b["question_text"]],
+                        "answer": [{"format": "SQL", "content": [b["answer_text"]]}],
+                    }
+                    for i, b in enumerate(room.benchmarks)
+                ]
+            }
+
+        return json.dumps(space)
+
+    @staticmethod
+    def _genie_id(section: str, index: int) -> str:
+        """Deterministic 32-char id for a serialized-space element.
+
+        Genie space ids are 32-char strings; we keep them stable and collision-free
+        by encoding the section (1=question, 2=sql, 3=text, 4=function, 5=benchmark)
+        in the leading digit and the element index in the trailing digits.
+        """
+        return section + str(index + 1).zfill(31)
 
     # we need to have the table existing before creating the genie room, however they're created in SDP which is in a job and not yet available.
     # This is a workaround to create a temp table with a property that will be used to delete it once the genie room is created so that the SDP table can run without issue.
@@ -258,6 +291,12 @@ class InstallerGenie:
                         if debug:
                             print(f"Copying {s3_url} to {target_path}")
                         response = requests.get(s3_url)
+                        if response.status_code == 404:
+                            # Not synced to the S3 mirror yet (e.g. a new/updated demo). Fall back
+                            # to the file in the GitHub dataset repo so the install still works.
+                            print(f"WARN: {file_name} is missing from the S3 mirror ({s3_url}). "
+                                  f"Falling back to the GitHub dataset repo: {file_url}")
+                            response = requests.get(file_url)
                         response.raise_for_status()
                         if debug:
                             print(f"File {file_name} in memory. sending to volume...")

--- a/dbdemos/installer_report.py
+++ b/dbdemos/installer_report.py
@@ -348,7 +348,8 @@ class InstallerReport:
                     error_already_installed  = ""
                     html += f"""<div>ERROR INSTALLING DASHBOARD {d['name']}: {d['error']}. The Import/Export API must be enabled.{error_already_installed}</div>"""
                 else:
-                    html += f"""<div>{InstallerReport.DASHBOARD_SVG} <a href="{self.workspace_url}/sql/dashboardsv3/{d['uid']}">{d['name']}</a></div>"""
+                    dashboard_url = d.get("published_url") or f"{self.workspace_url}/sql/dashboardsv3/{d['uid']}"
+                    html += f"""<div>{InstallerReport.DASHBOARD_SVG} <a href="{dashboard_url}">{d['name']}</a></div>"""
             html +="</div>"
         if len(genie_rooms) > 0:
             html += f"""<h2>Databricks AI/BI Genie Spaces: Talk to your data</h2><div class="container_dbdemos">"""
@@ -413,7 +414,8 @@ class InstallerReport:
                 if "error" in d:
                     print(f"    - ERROR INSTALLING DASHBOARD {d['name']}: {d['error']}. The Import/Export API must be enabled.{error_already_installed}")
                 else:
-                    print(f"    - {d['name']}: {self.workspace_url}/sql/dashboardsv3/{d['uid']}")
+                    dashboard_url = d.get("published_url") or f"{self.workspace_url}/sql/dashboardsv3/{d['uid']}"
+                    print(f"    - {d['name']}: {dashboard_url}")
         if len(genie_rooms) > 0:
             print("----------------------------------------------------")
             print("------------- Genie Spaces available: -----------")

--- a/package.py
+++ b/package.py
@@ -1,0 +1,221 @@
+"""
+package.py — bundle & package ALL dbdemos from environment-variable config.
+
+Equivalent to the bundling flow in main.py, but driven entirely by env vars so
+it can run unattended (CI, scheduled job, etc.). It scans the staging repo for
+every demo, runs their bundle jobs, and packages all of them. There is no final
+install test — it bundles everything and packages.
+
+Required environment variables
+-------------------------------
+  DATABRICKS_HOST   Workspace URL, e.g. https://e2-demo-tools.cloud.databricks.com
+  DATABRICKS_PAT    Personal access token for that workspace
+  GITHUB_TOKEN      GitHub token used to pull / diff the notebooks repo
+
+Optional environment variables (sensible defaults shown)
+--------------------------------------------------------
+  DBDEMOS_USERNAME        Workspace user (default: auto-detected from the token)
+  DBDEMOS_ORG_ID          Workspace org/id (default: auto-detected from the token)
+  DBDEMOS_REPO_STAGING    Staging /Repos path (default: /Repos/<username>)
+  DBDEMOS_REPO_NAME       Repo name (default: dbdemos-notebooks)
+  DBDEMOS_REPO_URL        Repo URL (default: https://github.com/databricks-demos/dbdemos-notebooks)
+  DBDEMOS_BRANCH          Branch to bundle from (default: main)
+  DBDEMOS_FORCE           "1"/"true" to force job re-execution (default: false)
+
+Exit codes
+----------
+  0  all demos bundled & packaged successfully
+  1  a clear, stage-tagged error was raised (see message)
+"""
+import os
+import sys
+import json
+import traceback
+
+from dbdemos.conf import Conf
+from dbdemos.job_bundler import JobBundler
+from dbdemos.packager import Packager
+
+
+class PackagingError(Exception):
+    """Raised when a packaging stage fails, with the stage name and root cause."""
+
+    def __init__(self, stage: str, cause: BaseException):
+        self.stage = stage
+        self.cause = cause
+        super().__init__(f"[stage: {stage}] {cause}")
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value or not value.strip():
+        raise PackagingError(
+            "config",
+            ValueError(
+                f"Missing required environment variable '{name}'. "
+                f"Set DATABRICKS_HOST, DATABRICKS_PAT and GITHUB_TOKEN before running."
+            ),
+        )
+    return value.strip()
+
+
+def _optional_env(name: str, default: str) -> str:
+    value = os.environ.get(name)
+    return value.strip() if value and value.strip() else default
+
+
+def _truthy(value: str) -> bool:
+    return value.lower() in ("1", "true", "yes", "on")
+
+
+def _read_resource(path: str) -> str:
+    try:
+        with open(path, "r") as f:
+            return f.read()
+    except OSError as e:
+        raise PackagingError("config", FileNotFoundError(f"Couldn't read resource file '{path}': {e}"))
+
+
+def _detect_workspace_identity(host: str, pat_token: str):
+    """Auto-detect (username, org_id) from the workspace so the caller only needs host+token."""
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        ws = WorkspaceClient(host=host, token=pat_token)
+        username = ws.current_user.me().user_name
+        # workspace_id is the org_id used throughout dbdemos
+        org_id = str(ws.get_workspace_id())
+        return username, org_id
+    except Exception as e:
+        raise PackagingError(
+            "config",
+            RuntimeError(
+                f"Couldn't authenticate to '{host}' and detect the workspace identity "
+                f"(username / org_id) from DATABRICKS_PAT. Verify the host URL and token. "
+                f"Root cause: {e}"
+            ),
+        )
+
+
+def build_conf() -> Conf:
+    """Build a dbdemos Conf from environment variables, auto-detecting what we can."""
+    host = _require_env("DATABRICKS_HOST").rstrip("/")
+    pat_token = _require_env("DATABRICKS_PAT")
+    github_token = _require_env("GITHUB_TOKEN")
+
+    username = os.environ.get("DBDEMOS_USERNAME", "").strip()
+    org_id = os.environ.get("DBDEMOS_ORG_ID", "").strip()
+    if not username or not org_id:
+        detected_user, detected_org = _detect_workspace_identity(host, pat_token)
+        username = username or detected_user
+        org_id = org_id or detected_org
+
+    repo_staging_path = _optional_env("DBDEMOS_REPO_STAGING", f"/Repos/{username}")
+    repo_name = _optional_env("DBDEMOS_REPO_NAME", "dbdemos-notebooks")
+    repo_url = _optional_env("DBDEMOS_REPO_URL", "https://github.com/databricks-demos/dbdemos-notebooks")
+    branch = _optional_env("DBDEMOS_BRANCH", "main")
+
+    default_cluster_template = _read_resource("./dbdemos/resources/default_cluster_config.json")
+    default_cluster_job_template = _read_resource("./dbdemos/resources/default_test_job_conf.json")
+
+    print(
+        "dbdemos packaging configuration:\n"
+        f"  host           : {host}\n"
+        f"  username       : {username}\n"
+        f"  org_id         : {org_id}\n"
+        f"  repo           : {repo_url} (branch: {branch})\n"
+        f"  repo_name      : {repo_name}\n"
+        f"  staging_path   : {repo_staging_path}\n"
+        "  (DATABRICKS_PAT / GITHUB_TOKEN loaded from env — not displayed)"
+    )
+
+    return Conf(
+        username,
+        host,
+        org_id,
+        pat_token,
+        default_cluster_template,
+        default_cluster_job_template,
+        repo_staging_path,
+        repo_name,
+        repo_url,
+        branch,
+        github_token=github_token,
+    )
+
+
+def _run_stage(stage: str, fn):
+    """Run a packaging stage, converting any failure into a clear PackagingError."""
+    print(f"\n========== STAGE: {stage} ==========")
+    try:
+        return fn()
+    except PackagingError:
+        raise
+    except Exception as e:
+        raise PackagingError(stage, e) from e
+
+
+def package_all_demos(conf: Conf):
+    force = _truthy(_optional_env("DBDEMOS_FORCE", "false"))
+
+    bundler = JobBundler(conf)
+
+    _run_stage(
+        "reset staging repo",
+        lambda: bundler.reset_staging_repo(skip_pull=False),
+    )
+
+    _run_stage(
+        "scan & load all bundles",
+        bundler.load_bundles_conf,
+    )
+
+    bundle_count = len(bundler.bundles)
+    if bundle_count == 0:
+        raise PackagingError(
+            "scan & load all bundles",
+            RuntimeError(
+                "No bundles found in the staging repo. Check the repo / branch / staging path."
+            ),
+        )
+    print(f"Found {bundle_count} demo bundles to package.")
+
+    _run_stage(
+        "run & wait for all bundle jobs",
+        lambda: bundler.start_and_wait_bundle_jobs(
+            force_execution=force, skip_execution=False, recreate_jobs=False
+        ),
+    )
+
+    packager = Packager(conf, bundler)
+    _run_stage(
+        "package all demos",
+        packager.package_all,
+    )
+
+    print(f"\n✅ Successfully bundled & packaged all {bundle_count} demos.")
+
+
+def main():
+    try:
+        conf = build_conf()
+        package_all_demos(conf)
+    except PackagingError as e:
+        # Clear, stage-tagged failure. Print the chain but never the token.
+        print("\n❌ PACKAGING FAILED", file=sys.stderr)
+        print(f"   Stage : {e.stage}", file=sys.stderr)
+        print(f"   Error : {e.cause}", file=sys.stderr)
+        print("\n--- traceback ---", file=sys.stderr)
+        traceback.print_exception(type(e.cause), e.cause, e.cause.__traceback__, file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        # Anything unexpected that escaped stage handling — still fail clearly.
+        print("\n❌ PACKAGING FAILED (unexpected error)", file=sys.stderr)
+        print(f"   Error : {e}", file=sys.stderr)
+        print("\n--- traceback ---", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,12 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     setup_requires=["wheel"],
     include_package_data=True,
-    install_requires=["requests", "pandas", "databricks-sdk>=0.38.0"],
+    install_requires=[
+        "requests==2.33.0",
+        "pandas==3.0.1",
+        "databricks-sdk==0.114.0",
+        "cryptography==46.0.6",  # Transitive dep, pinned for CVE-2026-34073
+    ],
     license="Databricks License",
     license_files = ('LICENSE',),
     tests_require=[


### PR DESCRIPTION
## Summary

Several related improvements to the demo install/packaging flow.

### Genie spaces → Databricks SDK
- Replace the raw `2.0/data-rooms` API with the `databricks-sdk` `GenieAPI` (`create_space` + `serialized_space`). Bumps `databricks-sdk` to `0.114.0`.
- New `build_serialized_space` maps every existing `GenieRoom` construct (tables, sample questions, text instructions, example SQLs, `sql_functions`, benchmarks) to the version-2 serialized schema.
- `data_sources.tables` are sorted by identifier (required by the API — otherwise it returns `Invalid export proto: data_sources.tables must be sorted by identifier`).
- **Existing bundle configs work unchanged** — the mapping is entirely internal; no demo edits required.

### Cloud detection consolidation
- `get_current_cloud()` now derives the cloud from `workspace_url` via a single `_infer_cloud_from_url` helper, instead of a second dbutils-hostname detection path that could disagree with `__init__`. Supersedes #260.

### Publish dashboards by default
- After a dashboard is created it is now published (`lakeview.publish`, viewer credentials), and the published URL (`/dashboardsv3/<id>/published?o=<org_id>`) is shown in the HTML summary and console. Publishing failures are non-fatal — the draft dashboard still installs.

### Data load: S3 → GitHub fallback
- When a dataset file is missing from the S3 mirror (e.g. a new/updated demo not yet synced), fall back to the GitHub dataset repo with a WARN, instead of failing with a 404.

### New `package.py`
- Env-var-driven (`DATABRICKS_HOST` / `DATABRICKS_PAT` / `GITHUB_TOKEN`) script that bundles & packages all demos. Auto-detects `username`/`org_id` from the token, emits clear stage-tagged errors, and exits 1 on failure. Secrets are never printed.

## Testing
- Genie create_space verified live (all six constructs) against e2-demo-tools; test spaces trashed after.
- Table-sort fix reproduced and verified against the failing `aibi-customer-support` room.
- Dashboard publish verified live end-to-end; URL format confirmed; test dashboard trashed.
- S3→GitHub fallback verified (`regions.parquet` 404s on S3, 200 on GitHub).
- `package.py` config + error paths verified (missing env → exit 1; identity auto-detect).

This pull request and its description were written by Isaac.